### PR TITLE
plotter: reduce and improve device charts plotted

### DIFF
--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -1,208 +1,267 @@
-use std::collections::HashMap;
+use std::cmp::max;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use plotters::prelude::*;
 
 use crate::app_data::AppDataJson;
 
 
+#[derive(Debug)]
+struct StatData
+{
+    label: String,
+    points: Vec<(f64, f64)>,
+}
+
+impl StatData
+{
+    fn add_point(&mut self, pt: (f64, f64))
+    {
+        self.points.push(pt);
+    }
+
+    fn new(label: &str) -> StatData
+    {
+        StatData {
+            label: label.to_string(),
+            points: Vec::new(),
+        }
+    }
+}
+
+const CHART_MEMINFO: usize = 0;
+const CHART_ENGINES: usize = 1;
+const CHART_FREQS: usize = 2;
+const CHART_POWER: usize = 3;
+const CHARTS_TOTAL: usize = 4;
+
+#[derive(Debug)]
 pub struct Plotter
 {
     jsondata: AppDataJson,
-    output_file: String,
-    charts_filter: Option<Vec<String>>,
+    out_prefix: String,
+    dev_slot: Option<String>,
+    sel_charts: [bool; CHARTS_TOTAL],
 }
 
 impl Plotter
 {
-    pub fn new(jsondata: AppDataJson, output_file: String,
-        charts_filter: Option<Vec<String>>) -> Plotter
+    fn plot_chart(&self, out_file: &str, title: &str,
+        x_desc: &str, y_desc: &str, x_max: f64, y_max: f64,
+        datasets: &Vec<StatData>) -> Result<()>
     {
-        Plotter {
-            jsondata,
-            output_file,
-            charts_filter,
-        }
-    }
-
-    pub fn plot(&self) -> Result<()>
-    {
-        let devices = self.jsondata.states();
-
-        let metrics = vec![
-            "min_freq", "cur_freq", "act_freq", "max_freq", "gpu_cur_power",
-            "pkg_cur_power", "smem_used", "vram_used", "ccs", "rcs", "vecs",
-            "vcs", "bcs",
-        ];
-
-        let mut valid_charts: HashMap<String, Vec<(String, String, f64, usize, f64)>> = HashMap::new();
-
-        let mut timestamp: usize = 0;
-
-        for device in devices {
-            if let Some(last_timestamp) = device.timestamps.back() {
-                timestamp = *last_timestamp as usize;
-            }
-            for dev_state in &device.devs_state {
-                let pci_dev = &dev_state.pci_dev;
-                let dev_name = &dev_state.vdr_dev_rev;
-                let stats = &dev_state.dev_stats;
-                let freq_limits_max = &dev_state.freq_limits[0].maximum;
-
-                for metric_name in &metrics {
-                    if let Some(filter) = &self.charts_filter {
-                        if !filter.contains(&metric_name.to_string()) {
-                            continue;
-                        }
-                    }
-
-                    let mut values = vec![];
-                    match *metric_name {
-                        "min_freq" => values.extend(
-                            stats.freqs.iter().map(|f| f[0].min_freq as f64),
-                        ),
-                        "cur_freq" => values.extend(
-                            stats.freqs.iter().map(|f| f[0].cur_freq as f64),
-                        ),
-                        "act_freq" => values.extend(
-                            stats.freqs.iter().map(|f| f[0].act_freq as f64),
-                        ),
-                        "max_freq" => values.extend(
-                            stats.freqs.iter().map(|f| f[0].max_freq as f64),
-                        ),
-                        "gpu_cur_power" => values.extend(
-                            stats.power.iter().map(|p| p.gpu_cur_power as f64),
-                        ),
-                        "pkg_cur_power" => values.extend(
-                            stats.power.iter().map(|p| p.pkg_cur_power as f64),
-                        ),
-                        "smem_used" => values.extend(
-                            stats.mem_info.iter().map(|m| m.smem_used as f64),
-                        ),
-                        "vram_used" => values.extend(
-                            stats.mem_info.iter().map(|m| m.vram_used as f64),
-                        ),
-                        engine_name if stats.eng_usage.contains_key(engine_name) => {
-                            if let Some(engine_stats) =
-                                stats.eng_usage.get(engine_name)
-                            {
-                                values.extend(
-                                    engine_stats.iter().map(|&u| u as f64),
-                                );
-                            }
-                        }
-                        _ => {
-                            println!(
-                                "Metric does not match any known category: {}",
-                                metric_name
-                            );
-                        }
-                    }
-
-                    if let Some(last_value) = values.last() {
-                        if *last_value > 0.0 {
-                            valid_charts
-                                .entry(pci_dev.clone())
-                                .or_insert_with(Vec::new)
-                                .push((
-                                    dev_name.to_string(),
-                                    metric_name.to_string(),
-                                    *last_value,
-                                    timestamp,
-                                    *freq_limits_max as f64,
-                                ));
-                        }
-                    }
-                }
-            }
-        }
-
-        let max_x = timestamp;
-        let mut max_y;
-
-        let mut max_power = f64::NEG_INFINITY;
-        let mut max_mem = f64::NEG_INFINITY;
-
-        let mut metrics_grouped: HashMap<
-            String,
-            Vec<(String, String, f64, usize, f64)>,
-        > = HashMap::new();
-
-        for (pci_dev, metrics) in &valid_charts {
-            for (dev_name, metric_name, value, timestamp, freq_max) in metrics {
-                metrics_grouped
-                    .entry(metric_name.clone())
-                    .or_insert_with(Vec::new)
-                    .push((
-                        pci_dev.clone(),
-                        dev_name.clone(),
-                        *value,
-                        *timestamp,
-                        freq_max.clone(),
-                    ));
-
-                if metric_name.contains("_power") {
-                    max_power = max_power.max(*value);
-                } else if metric_name.contains("mem") {
-                    max_mem = max_mem.max(*value);
-                }
-            }
-        }
-
-        let cols = 1;
-        let rows = metrics_grouped.len();
-        let root = BitMapBackend::new(&self.output_file, (1200, 2000))
+        let root = SVGBackend::new(out_file, (1200, 720))
             .into_drawing_area();
         root.fill(&WHITE)?;
-        let areas = root.split_evenly((rows, cols));
 
-        for ((metric_name, data), area) in metrics_grouped.into_iter().zip(areas)
-        {
-            match metric_name.clone() {
-                name if name.contains("_freq") => {
-                    max_y = data
-                        .iter()
-                        .map(|(_, _, value, _, _)| *value)
-                        .fold(f64::NEG_INFINITY, f64::max);
+        let mut chart = ChartBuilder::on(&root)
+            .caption(title, ("sans-serif", (5).percent_height()))
+            .set_label_area_size(LabelAreaPosition::Left, (8).percent())
+            .set_label_area_size(LabelAreaPosition::Bottom, (4).percent())
+            .margin((1).percent())
+            .build_cartesian_2d(0.0..x_max, 0.0..y_max)?;
+        chart
+            .configure_mesh()
+            .x_desc(x_desc)
+            .y_desc(y_desc)
+            .draw()?;
+
+        for (idx, ds) in datasets.iter().enumerate() {
+            let color = Palette99::pick(idx).mix(0.9);
+            chart
+                .draw_series(LineSeries::new(
+                    ds.points.iter().map(|&pt| pt),
+                    color.stroke_width(3)))?
+                .label(&ds.label)
+                .legend(move |(x, y)| Rectangle::new([(x, y - 5),
+                    (x + 10, y + 5)], color.filled()));
+        }
+        chart.configure_series_labels().border_style(BLACK).draw()?;
+
+        root.present()?;
+        println!("qmassa: Chart {:?} saved to {:?}", title, out_file);
+
+        Ok(())
+    }
+
+    // TODO: figure out plotting DRM client stats charts
+    pub fn plot(&self) -> Result<()>
+    {
+        let all_devs = self.dev_slot.is_none();
+        let plot_meminfo = self.sel_charts[CHART_MEMINFO];
+        let plot_engines = self.sel_charts[CHART_ENGINES];
+        let plot_freqs = self.sel_charts[CHART_FREQS];
+        let plot_power = self.sel_charts[CHART_POWER];
+        let nr_devices = self.jsondata
+            .states().front().unwrap().devs_state.len();
+
+        for idx in 0..nr_devices {
+            let di = &self.jsondata.states().front().unwrap().devs_state[idx];
+            if !all_devs && &di.pci_dev != self.dev_slot.as_ref().unwrap() {
+                continue;
+            }
+
+            let mut meminfo: Vec<StatData> = Vec::new();
+            let mut engines: Vec<StatData> = Vec::new();
+            let mut freqs: Vec<Vec<StatData>> = Vec::new();
+            let mut power: Vec<StatData> = Vec::new();
+            let mut max_power = 0.0;
+
+            if plot_meminfo {
+                meminfo.push(StatData::new("SMEM"));
+                if di.dev_type.is_discrete() {
+                    meminfo.push(StatData::new("VRAM"));
                 }
-                name if name.contains("_power") => {
-                    max_y = max_power;
+            }
+            if plot_engines {
+                for en in di.eng_names.iter() {
+                    engines.push(StatData::new(&en.to_uppercase()));
                 }
-                name if name.contains("_mem") => {
-                    max_y = max_mem;
+            }
+            if plot_freqs {
+                for _ in di.freq_limits.iter() {
+                    let mut nv = Vec::new();
+                    nv.push(StatData::new("MIN"));
+                    nv.push(StatData::new("MAX"));
+                    nv.push(StatData::new("REQ"));
+                    nv.push(StatData::new("ACT"));
+                    freqs.push(nv);
                 }
-                _ => {
-                    max_y = 100.0;
+            }
+            if plot_power {
+                power.push(StatData::new("GPU"));
+                power.push(StatData::new("PKG"));
+            }
+
+            for state in self.jsondata.states().iter() {
+                let tstamp = *state.timestamps.back().unwrap() as f64 / 1000.0;
+                let dinfo = &state.devs_state[idx];
+
+                if plot_meminfo {
+                    let mi = dinfo.dev_stats.mem_info.back().unwrap();
+                    meminfo[0].add_point((tstamp,
+                        mi.smem_used as f64 / (1024.0 * 1024.0)));
+                    if dinfo.dev_type.is_discrete() {
+                        meminfo[1].add_point((tstamp,
+                            mi.vram_used as f64 / (1024.0 * 1024.0)));
+                    }
+                }
+                if plot_engines {
+                    for (nr, en) in dinfo.eng_names.iter().enumerate() {
+                        let eu = *dinfo.dev_stats.eng_usage[en].back().unwrap();
+                        engines[nr].add_point((tstamp, eu));
+                    }
+                }
+                if plot_freqs {
+                    let fq = dinfo.dev_stats.freqs.back().unwrap();
+                    for nr in 0..dinfo.freq_limits.len() {
+                        freqs[nr][0]
+                            .add_point((tstamp, fq[nr].min_freq as f64));
+                        freqs[nr][1]
+                            .add_point((tstamp, fq[nr].max_freq as f64));
+                        freqs[nr][2]
+                            .add_point((tstamp, fq[nr].cur_freq as f64));
+                        freqs[nr][3]
+                            .add_point((tstamp, fq[nr].act_freq as f64));
+                    }
+                }
+                if plot_power {
+                    let pwr = dinfo.dev_stats.power.back().unwrap();
+                    max_power = f64::max(max_power, pwr.gpu_cur_power);
+                    max_power = f64::max(max_power, pwr.pkg_cur_power);
+                    power[0].add_point((tstamp, pwr.gpu_cur_power));
+                    power[1].add_point((tstamp, pwr.pkg_cur_power));
                 }
             }
 
-            let mut chart = ChartBuilder::on(&area)
-                .caption(
-                    format!(
-                        "{} for {}",
-                        metric_name,
-                        data.first()
-                            .map(|(_, dev_name, _, _, _)| dev_name)
-                            .unwrap_or(&String::new())
-                    ),
-                    ("sans-serif", 12),
-                )
-                .x_label_area_size(20)
-                .y_label_area_size(40)
-                .build_cartesian_2d(0..max_x as i32, 0.0..max_y)?;
+            let last_state = self.jsondata.states().back().unwrap();
+            let x_max = *last_state.timestamps.back().unwrap() as f64 / 1000.0;
 
-            chart.configure_mesh().draw()?;
-
-            let points: Vec<(i32, f64)> = data
-                .iter()
-                .map(|(_, _, value, timestamp, _)| (*timestamp as i32, *value))
-                .collect();
-
-            chart.draw_series(LineSeries::new(points, &BLUE))?;
+            if plot_meminfo {
+                let out_file = format!("{}-{}-meminfo.svg",
+                    &self.out_prefix, &di.pci_dev);
+                let mi = di.dev_stats.mem_info.back().unwrap();
+                let y_max = max(mi.smem_total, mi.vram_total) as f64 /
+                    (1024.0 * 1024.0);
+                self.plot_chart(
+                    &out_file, &format!("{} - Memory Info", &di.vdr_dev_rev),
+                    "Time (s)", "Memory used (MiB)",
+                    x_max, y_max, &meminfo)?;
+            }
+            if plot_engines {
+                let out_file = format!("{}-{}-engines.svg",
+                    &self.out_prefix, &di.pci_dev);
+                self.plot_chart(
+                    &out_file, &format!("{} - Engines Usage", &di.vdr_dev_rev),
+                    "Time (s)", "Usage (%)",
+                    x_max, 100.0, &engines)?;
+            }
+            if plot_freqs {
+                for (nr, fl) in di.freq_limits.iter().enumerate() {
+                    let out_file = format!("{}-{}-freqs-{}.svg",
+                        &self.out_prefix, &di.pci_dev, &fl.name);
+                    self.plot_chart(
+                        &out_file,
+                        &format!("{} - {} Frequencies",
+                            &di.vdr_dev_rev, &fl.name.to_uppercase()),
+                        "Time (s)", "Frequency (MHz)",
+                        x_max, fl.maximum as f64, &freqs[nr])?;
+                }
+            }
+            if plot_power {
+                let out_file = format!("{}-{}-power.svg",
+                    &self.out_prefix, &di.pci_dev);
+                self.plot_chart(
+                    &out_file, &format!("{} - Power Usage", &di.vdr_dev_rev),
+                    "Time (s)", "Power (W)",
+                    x_max, max_power, &power)?;
+            }
         }
 
-        root.present()?;
-        println!("Charts saved to {}", self.output_file);
         Ok(())
+    }
+
+    pub fn from(jsondata: AppDataJson, out_prefix: String,
+        dev_slot: Option<String>, charts_opt: Option<String>) -> Result<Plotter>
+    {
+        if let Some(dev) = &dev_slot {
+            let mut valid = false;
+            for d in jsondata.states().front().unwrap().devs_state.iter() {
+                if d.pci_dev == *dev {
+                    valid = true;
+                }
+            }
+            if !valid {
+                bail!("No DRM GPU device {:?} in the JSON file", dev);
+            }
+        }
+
+        let sel_charts = if let Some(charts_str) = charts_opt {
+            let mut sc = [false; CHARTS_TOTAL];
+            let charts: Vec<_> = charts_str
+                .split(",")
+                .collect();
+
+            for c in charts.into_iter() {
+                match c {
+                    "meminfo" => sc[CHART_MEMINFO] = true,
+                    "engines" => sc[CHART_ENGINES] = true,
+                    "freqs" => sc[CHART_FREQS] = true,
+                    "power" => sc[CHART_POWER] = true,
+                    _ => bail!("Invalid chart {:?} requested", c),
+                }
+            }
+
+            sc
+        } else {
+            [true; CHARTS_TOTAL]
+        };
+
+        Ok(Plotter {
+            jsondata,
+            out_prefix,
+            dev_slot,
+            sel_charts,
+        })
     }
 }


### PR DESCRIPTION
Limit charts to be per device and just 4 type: memory info, engines usage, frequencies, and power usage.

Command-line options can select which device to plot charts for (default: all of them) and which charts (default: all the 4 charts).

Each chart is saved into a separate SVG file with the prefix provided in the command line switch for the plot sub-command.

Closes: #5