### PR TITLE
qmlib/amdgpu: handle absent *_busy_percent sysfs counters on APUs

### DIFF
--- a/qmlib/src/drm_drivers/amdgpu.rs
+++ b/qmlib/src/drm_drivers/amdgpu.rs
@@ -454,23 +454,24 @@ impl DrmDriver for DrmDriverAmdgpu
             return Ok(HashMap::new());
         }
 
-        let fpath = self.dev_dir.join("gpu_busy_percent");
-        let sval = fs::read_to_string(&fpath)?;
-        let gpu_val: f64 = sval.trim().parse()?;
+        // Each `*_busy_percent` sysfs file is optional: AMD APUs never expose
+        // `mem_busy_percent`, so a missing file must only skip that engine
+        // instead of aborting the whole refresh. Any other read or parse error
+        // still propagates.
+        let mut engs = HashMap::new();
+        for (key, file) in [
+            ("gpu", "gpu_busy_percent"),
+            ("vcn", "vcn_busy_percent"),
+            ("mem", "mem_busy_percent"),
+        ] {
+            if let Some(val) = DrmDriverAmdgpu::read_optional_percent(
+                &self.dev_dir, file)?
+            {
+                engs.insert(String::from(key), val);
+            }
+        }
 
-        let fpath = self.dev_dir.join("vcn_busy_percent");
-        let sval = fs::read_to_string(&fpath)?;
-        let vcn_val: f64 = sval.trim().parse()?;
-
-        let fpath = self.dev_dir.join("mem_busy_percent");
-        let sval = fs::read_to_string(&fpath)?;
-        let mem_val: f64 = sval.trim().parse()?;
-
-        Ok(HashMap::from([
-            (String::from("gpu"), gpu_val),
-            (String::from("vcn"), vcn_val),
-            (String::from("mem"), mem_val),
-        ]))
+        Ok(engs)
     }
 
     fn temps(&mut self) -> Result<Vec<DrmDeviceTemperature>>
@@ -494,6 +495,18 @@ impl DrmDriver for DrmDriverAmdgpu
 
 impl DrmDriverAmdgpu
 {
+    /// Read a `*_busy_percent` sysfs counter. Returns `Ok(None)` when the
+    /// file is absent (e.g. AMD APUs don't expose `mem_busy_percent`); any
+    /// other read or parse failure is returned as an error.
+    fn read_optional_percent(dev_dir: &Path, file: &str) -> Result<Option<f64>>
+    {
+        match fs::read_to_string(dev_dir.join(file)) {
+            Ok(s) => Ok(Some(s.trim().parse()?)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     fn info_ioctl(dn_fd: RawFd,
         query_id: u32, data: u64, size: u32) -> Result<()>
     {
@@ -592,5 +605,42 @@ impl DrmDriverAmdgpu
         }
 
         Ok(Rc::new(RefCell::new(amdgpu)))
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch_dir(name: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!("qmlib_amdgpu_{}_{}", std::process::id(), name));
+        let _ = fs::remove_dir_all(&p);
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn missing_percent_file_is_skipped() {
+        let dir = scratch_dir("missing");
+        // gpu_busy_percent present -> parsed
+        fs::write(dir.join("gpu_busy_percent"), "42").unwrap();
+        assert_eq!(
+            DrmDriverAmdgpu::read_optional_percent(&dir, "gpu_busy_percent").unwrap(),
+            Some(42.0)
+        );
+        // mem_busy_percent absent (as on AMD APUs) -> None, no error
+        assert_eq!(
+            DrmDriverAmdgpu::read_optional_percent(&dir, "mem_busy_percent").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn unparseable_percent_value_errors() {
+        let dir = scratch_dir("badval");
+        fs::write(dir.join("gpu_busy_percent"), "not-a-number").unwrap();
+        assert!(DrmDriverAmdgpu::read_optional_percent(&dir, "gpu_busy_percent").is_err());
     }
 }


### PR DESCRIPTION
AMD APUs never expose `mem_busy_percent` in sysfs — the kernel only creates it for non-APU parts (`drivers/gpu/drm/amd/pm/amdgpu_pm.c`). Since `engs_utilization()` reads it with `?`, that ENOENT propagates all the way up through `DrmDeviceInfo::refresh()` and aborts the entire refresh on every cycle. The device gets discovered fine, but no stats are ever collected. This was originally reported on gfx1101 (Radeon 780M) in #37, and I ran into the same thing on gfx1151 (Strix Halo).

The fix makes each per-engine `*_busy_percent` read optional: if the file doesn't exist, that counter is skipped; if it exists but can't be read or parsed, that's still a real error and propagates like before. It reuses the crate's existing `Result<Option<T>>` idiom and keeps the change contained to `qmlib/src/drm_drivers/amdgpu.rs` — `refresh()` and the other DRM drivers are untouched.

I've left the separate gap where integrated APUs report no power or temperature (hwmon is only wired up for discrete GPUs — there's a `// TODO: need to add integrated support` in `power()`) as a follow-up.

## Tested on AMD gfx1151 (Strix Halo)

I built the `qmassa` CLI with this patch and ran it on the APU with `engines=sysfs`, 3 iterations at 1s intervals.

**Before (stock qmassa):**

```
$ qmassa -x --nr-iterations 3 --ms-interval 1000 -o amdgpu=engines=sysfs --to-json qmassa.json
Error: No such file or directory (os error 2)
```

The JSON only contains the CLI-args header — the `devs_state` block (engine usage, frequencies, memory info) never gets written, because the `mem_busy_percent` ENOENT aborts the refresh every cycle.

**After (this patch):** the APU is discovered as integrated and stats collect normally. `eng_names` only includes the engines whose `*_busy_percent` file actually exists, so the missing `mem_busy_percent` is skipped rather than fatal:

```json
{
  "pci_id": "1002:1586",
  "dev_type": { "Integrated": "NoVirt" },
  "drv_name": "amdgpu",
  "dev_nodes": "card0, renderD128",
  "eng_names": ["gpu", "vcn"],
  "eng_usage": {
    "gpu": [100.0, 100.0, 100.0],
    "vcn": [0.0, 0.0, 0.0]
  },
  "freqs": [
    [...{ "act_freq": 2817 }],
    [...{ "act_freq": 2869 }],
    [...{ "act_freq": 2889 }]
  ],
  "mem_info": [{
    "smem_total": 133143986176,
    "smem_used":  78534258688,
    "vram_total": 536870912,
    "vram_used":  201940992
  }]
}
```

`power`, `temps`, and `fans` come back empty for the APU — that's the separate integrated-hwmon gap mentioned above, not this change.

## Verification

- `cargo build --all` and `cargo test --all` pass. I added two unit tests covering the missing-file and bad-value paths of the new helper.
- `cargo clippy --all-targets` adds no new warnings — the only ones are 8 pre-existing `&String` -> `&str` lints in `qmmd/src/stats_ctrl.rs`, unrelated to this change.
- `cargo fmt --all -- --check` reports differences across the repo (there's no committed `rustfmt.toml` and the codebase uses a hand-written brace style), so I followed the surrounding file's style to keep the diff minimal.

Fixes #37
